### PR TITLE
config: Create FlowIQ mapping file to associate Biowulf modules with Docker images

### DIFF
--- a/flowiq_mapping.json
+++ b/flowiq_mapping.json
@@ -22,6 +22,19 @@
     "bwa": {
         "bwa/0.7.17": "quay.io/biocontainers/bwa:0.7.17--ha92aebf_3"
     },
+    "cellranger": {
+        "cellranger/8.0.1": "cumulusprod/cellranger:8.0.1",
+        "cellranger/8.0.0": "cumulusprod/cellranger:8.0.0",
+        "cellranger/7.2.0": "nfcore/cellranger:7.2.0",
+        "cellranger/7.1.0": "nfcore/cellranger:7.1.0",
+        "cellranger/7.0.1": "cumulusprod/cellranger:7.0.1",
+        "cellranger/7.0.0": "nfcore/cellranger:7.0.0",
+        "cellranger/6.1.2": "nfcore/cellranger:6.1.2",
+        "cellranger/6.1.1": "cumulusprod/cellranger:6.1.1",
+        "cellranger/6.0.0": "cumulusprod/cellranger:6.0.0",
+        "cellranger/5.0.1": "cumulusprod/cellranger:5.0.1",
+        "cellranger/5.0.0": "cumulusprod/cellranger:5.0.0"
+    },
     "cutadapt": {
         "cutadapt/4.7": "quay.io/biocontainers/cutadapt:4.7--py310h4b81fae_1",
         "cutadapt/4.4": "quay.io/biocontainers/cutadapt:4.4--py39hf95cd2a_1",
@@ -39,6 +52,9 @@
         "fastqc/0.11.9": "quay.io/biocontainers/fastqc:0.11.9--0",
         "fastqc/0.11.8": "quay.io/biocontainers/fastqc:0.11.8--1"
     },
+    "freebayes": {
+        "freebayes/1.3.5": "quay.io/biocontainers/freebayes:1.3.5--py37h82443fc_4"
+    },
     "gatk": {
         "GATK/4.6.0.0": "broadinstitute/gatk:4.6.0.0",
         "GATK/4.5.0.0": "broadinstitute/gatk:4.5.0.0",
@@ -52,6 +68,11 @@
     "kraken": {
         "kraken/2.1.2": "quay.io/biocontainers/kraken2:2.1.2--pl5321h4ac6f70_4",
         "kraken/1.1": "quay.io/biocontainers/kraken:1.1--h470a237_2"
+    },
+    "macs": {
+        "macs/2.2.7.1": "quay.io/biocontainers/macs2:2.2.7.1--py36h91eb985_5",
+        "macs/3.0.2": "quay.io/biocontainers/macs3:3.0.2--py311h0152c62_1",
+        "macs/3.0.1": "quay.io/biocontainers/macs3:3.0.1--py312he57d009_3"
     },
     "multiqc": {
         "multiqc/1.22": "quay.io/biocontainers/multiqc:1.22--pyhdfd78af_0",
@@ -99,26 +120,5 @@
     },
     "vcftools": {
         "vcftools/0.1.16": "quay.io/biocontainers/vcftools:0.1.16--pl5321hdcf5f25_11"
-    },
-    "cellranger": {
-        "cellranger/8.0.1": "cumulusprod/cellranger:8.0.1",
-        "cellranger/8.0.0": "cumulusprod/cellranger:8.0.0",
-        "cellranger/7.2.0": "nfcore/cellranger:7.2.0",
-        "cellranger/7.1.0": "nfcore/cellranger:7.1.0",
-        "cellranger/7.0.1": "cumulusprod/cellranger:7.0.1",
-        "cellranger/7.0.0": "nfcore/cellranger:7.0.0",
-        "cellranger/6.1.2": "nfcore/cellranger:6.1.2",
-        "cellranger/6.1.1": "cumulusprod/cellranger:6.1.1",
-        "cellranger/6.0.0": "cumulusprod/cellranger:6.0.0",
-        "cellranger/5.0.1": "cumulusprod/cellranger:5.0.1",
-        "cellranger/5.0.0": "cumulusprod/cellranger:5.0.0"
-    },
-    "freebayes": {
-        "freebayes/1.3.5": "quay.io/biocontainers/freebayes:1.3.5--py37h82443fc_4"
-    },
-    "macs": {
-        "macs/2.2.7.1": "quay.io/biocontainers/macs2:2.2.7.1--py36h91eb985_5",
-        "macs/3.0.2": "quay.io/biocontainers/macs3:3.0.2--py311h0152c62_1",
-        "macs/3.0.1": "quay.io/biocontainers/macs3:3.0.1--py312he57d009_3"
     }
 }


### PR DESCRIPTION
**What**

This PR introduces a FlowIQ mapping file that maps modules on Biowulf to their corresponding Docker images. The Docker images were primarily sourced from the Biocontainers and nf-core repositories. We identified these images by examining the nf-core GitHub repository, specifically the modules folder, and reviewing the `main.nf` file for each tool to determine the specified containers.

<br>

**Why**
Task 2 of Aim 1 in the FlowIQ proposal specifies: 
>For the top 20 most utilized modules on Biowulf, initially search for equivalent modules and templates on nf-core, recording the mappings in the FlowIQ mapping file in JSON format. 


<br><br>

Fixes #4