### PR TITLE
Add S3 Mapping File for Test Data Types

### DIFF
--- a/test_data_mapping.json
+++ b/test_data_mapping.json
@@ -1,0 +1,67 @@
+{
+    "RNA-seq": {
+        "S3 Locations": [
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603392_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603392_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603393_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603393_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603629_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603629_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603630_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX1603630_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370468_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370468_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370469_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370469_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370490_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370490_T1_2.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370491_T1_1.fastq.gz",
+            "s3://ngi-igenomes/test-data/rnaseq/SRX2370491_T1_2.fastq.gz"
+        ],
+        "Description": "This dataset contains full-sized RNA-seq data from the ENCODE Project Consortium, publicly available for benchmarking and pipeline validation. The data consist of paired-end reads from four ENCODE cell lines (GM12878, K562, MCF7, and H1), each with two replicates. A total of 16 FASTQ files (123.5 GB, ~93 million reads per file) are available. These datasets have been used to benchmark RNA-seq quantification pipelines, including the nf-core RNA-seq pipeline, ensuring sensible resource allocation and persistent storage of results for comparisons between pipeline releases. Example test run results can be viewed at https://nf-co.re/rnaseq/3.17.0/results/rnaseq/results-00f924cf92a986a842bb352b3c4ae379c773c989. The following ENCODE experiment and run accessions are included: SRX1603629_T1 (SRR3192657), SRX1603630_T1 (SRR3192658), SRX1603392_T1 (SRR3192408), SRX1603393_T1 (SRR3192409), SRX2370490_T1 (SRR5048099), SRX2370491_T1 (SRR5048100), SRX2370468_T1 (SRR5048077), and SRX2370469_T1 (SRR5048078). These datasets were also used in the study 'A benchmark for RNA-seq quantification pipelines,' published in Genome Biology (2016), which can be accessed at https://pubmed.ncbi.nlm.nih.gov/27107712/ (DOI: 10.1186/s13059-016-0940-1)."
+    },
+
+    "Germline Variant Calling": {
+        "S3LocationsBAM": [
+            "s3://giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_Illumina_2x250bps/novoalign_bams/HG002.GRCh38.2x250.bam",
+            "s3://giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_Illumina_2x250bps/novoalign_bams/HG002.hs37d5.2x250.bam",
+            "s3://giab/data/AshkenazimTrio/HG003_NA24149_father/NIST_Illumina_2x250bps/novoalign_bams/HG003.GRCh38.2x250.bam",
+            "s3://giab/data/AshkenazimTrio/HG003_NA24149_father/NIST_Illumina_2x250bps/novoalign_bams/HG003.hs37d5.2x250.bam",
+            "s3://giab/data/AshkenazimTrio/HG004_NA24143_mother/NIST_Illumina_2x250bps/novoalign_bams/HG004.GRCh38.2x250.bam",
+            "s3://giab/data/AshkenazimTrio/HG004_NA24143_mother/NIST_Illumina_2x250bps/novoalign_bams/HG004.hs37d5.2x250.bam"
+        ],
+        "S3LocationsFASTQ": [
+            "s3://giab/data/AshkenazimTrio/HG002_NA24385_son/NIST_Illumina_2x250bps/reads/",
+            "s3://giab/data/AshkenazimTrio/HG003_NA24149_father/NIST_Illumina_2x250bps/reads/",
+            "s3://giab/data/AshkenazimTrio/HG004_NA24143_mother/NIST_Illumina_2x250bps/reads/"
+        ],
+        "TruthSetLocations": [
+            "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/AshkenazimTrio/HG002_NA24385_son/latest/GRCh38/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz",
+            "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/AshkenazimTrio/HG003_NA24149_father/latest/GRCh38/HG003_GRCh38_1_22_v4.2.1_benchmark.vcf.gz",
+            "https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/AshkenazimTrio/HG004_NA24143_mother/latest/GRCh38/HG004_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+        ],
+        "ReferenceFiles": {
+            "hs37d5": "ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/phase2_reference_assembly_sequence/hs37d5.fa.gz",
+            "GRCh38": "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz"
+        },
+        "Description": "These germline variant calling data are derived from the Ashkenazi Trio from Genome in a Bottle (GIAB), which consists of three deeply sequenced human genomes: a father, a mother, and their son, all of Ashkenazi Jewish descent. This trio serves as a high-confidence reference standard for benchmarking and validating genomic sequencing technologies and bioinformatics pipelines. Its significance lies in the trio's known familial relationships, which facilitate inheritance analysis and more accurate variant calling. Here we provide the AWS S3 locations for the BAM files of the mother, father, and son, aligned to both GRCh37 and GRCh38. Additionaly, we include the S3 folders containing the FASTQ files for each individual, as well as the locations for the reference files and the truth sets, which are accessible online."
+    },
+
+    "Genotype": {
+        "Genotype Locations": [
+            "s3://flowiq-test-data/simulated_1000genomes_genotype_phenotype/genotype/EUR_chr21.bed.gz",
+            "s3://flowiq-test-data/simulated_1000genomes_genotype_phenotype/genotype/EUR_chr21.bim.gz",
+            "s3://flowiq-test-data/simulated_1000genomes_genotype_phenotype/genotype/EUR_chr21.fam.gz"
+        ],
+        "Phenotype Locations": [
+            "s3://flowiq-test-data/simulated_1000genomes_genotype_phenotype/phenotype/EUR_pheno_rho_1_GA_1.txt.gz",
+            "s3://flowiq-test-data/simulated_1000genomes_genotype_phenotype/phenotype/EUR_pheno_rho_2_GA_1.txt.gz"
+        ],
+        "Description": "The webpage at https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/COXHAP offers a rich resource for researchers studying genetic diversity. It contains simulated genotype and phenotype data for 600,000 individuals across five populations (African, Admixed American, East Asian, European, and South Asian), with 120,000 subjects in each. These simulations leverage linkage disequilibrium estimates from the 1000 Genomes Project (Phase 3), providing a comprehensive dataset for diverse populations.  In addition to genotypes, the repository includes simulated phenotypes, GWAS summary statistics, and SNP information. Refer to this GitHub page https://github.com/andrewhaoyu/multi_ethnic for more details. To facilitate cloud-based analysis, we further processed this dataset. We downloaded the simulated genotype data for chromosome 21 of the European ancestry group (plink BED/BIM/FAM files) along with two sets of simulated phenotype data. These files have been uploaded to our AWS account and are freely available for download. This provides researchers with convenient access to a subset of the data for testing and developing cloud-based pipelines."
+    },
+
+    "Common Reference Genomes": {
+        "Download Script & Command Builder": "https://ewels.github.io/AWS-iGenomes/",
+        "Description": "Here we recommend the AWS-iGenomes tool (https://github.com/evison/evison.github.io), a user-friendly web interface that offers a comprehensive Download Script and Command Builder tool to seamlessly access commonly used reference genomes. These genomes originate from the Illumina iGenomes project but are conveniently stored on the AWS S3 bucket (s3://ngi-igenomes/) for streamlined cloud computing workflows. Notably, the resource integrates well with Nextflow, a popular pipeline management tool with extensive built-in support for various AWS features. This makes it ideal for researchers already utilizing Nextflow in their analysis.  Beyond the core reference genomes, the AWS-iGenomes project provides several additional indices for enhanced functionality with various tools.  This initiative aims to standardize a collection of commonly used species, reference genomes, and tool indices, ultimately simplifying the cloud-based analysis process. For a deeper dive into this valuable resource, please refer to the project's GitHub readme: https: //github.com/ewels/AWS-iGenomes."
+    }
+}


### PR DESCRIPTION
### What
This PR introduces a new S3 test data mapping file that links various data types to their respective locations on S3. The mapping includes both data stored in our public S3 bucket for researchers and references to existing test data locations on S3.

### Why
The goal of this addition is to enhance our landing page, similar to the Biowulf-to-Docker-image map. By providing a clear mapping of test data locations, we aim to facilitate easier access for researchers, enabling them to efficiently locate the necessary test data for validating their cloud pipelines.

<br><br>

Fixes #1 
